### PR TITLE
AVRO-1658: Java: Add reflection annotation @AvroDoc.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroDoc.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroDoc.java
@@ -1,0 +1,17 @@
+package org.apache.avro.reflect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sets the avrodoc for this java field.
+ * When reading into this class, a reflectdatumreader
+ * looks for a schema field with the avrodoc.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+public @interface AvroDoc {
+  String value();
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -1101,4 +1101,34 @@ public class TestReflect {
   public void testNullableByteArrayNullValue() throws Exception {
     checkReadWrite(new NullableBytesTest());
   }
+
+  private enum DocTestEnum {
+    ENUM_1,
+    ENUM_2
+  }
+
+  @AvroDoc("DocTest class docs")
+  private static class DocTest {
+    @AvroDoc("Some Documentation")
+    int foo;
+
+    @AvroDoc("Some other Documentation")
+    DocTestEnum enums;
+
+    @AvroDoc("And again")
+    DefaultTest defaultTest;
+  }
+
+  @Test
+  public void testAvroDoc() {
+    check(DocTest.class,
+            "{\"type\":\"record\",\"name\":\"DocTest\",\"namespace\":\"org.apache.avro.reflect.TestReflect$\","
+                    + "\"doc\":\"DocTest class docs\","
+                    + "\"fields\":[{\"name\":\"foo\",\"type\":\"int\",\"doc\":\"Some Documentation\"},"
+                    + "{\"name\":\"enums\",\"type\":{\"type\":\"enum\",\"name\":\"DocTestEnum\","
+                    + "\"symbols\":[\"ENUM_1\",\"ENUM_2\"]},\"doc\":\"Some other Documentation\"},"
+                    + "{\"name\":\"defaultTest\",\"type\":{\"type\":\"record\",\"name\":\"DefaultTest\","
+                    + "\"fields\":[{\"name\":\"foo\",\"type\":\"int\",\"default\":1}]},\"doc\":\"And again\"}]}");
+  }
+
 }


### PR DESCRIPTION
@AvroMeta can be used for other keys, but doc is passed into the field's
constructor.

Patch 2: @AvroDoc should work for class-level documentation too.